### PR TITLE
Readability fix for Dark Mode

### DIFF
--- a/index.html
+++ b/index.html
@@ -11,7 +11,7 @@
 	<title>Daily Journal</title>
 </head>
 
-<body class="w3-theme-dark || w3-theme-light">
+<body onload="makeDarkToggle()" class="w3-theme-dark || w3-theme-light bodyodyody">
 	<header class="pageHeader w3-container centered bottomSpace">
 		Val Currie's
 		<h1>Daily Journal</h1>
@@ -72,10 +72,17 @@
 	</footer>
  
 	<script>
-		const darkToggle = document.querySelector('.darkToggle');
-		darkToggle.addEventListener('click', function() {
-			document.body.classList.toggle('w3-theme-dark');
-		})
+		const makeDarkToggle = () => {
+			const darkToggle = document.querySelector('.darkToggle');
+			const noteHeaders = document.querySelectorAll('h6.note__header')
+			// const noteHeader = document.querySelector('.note__header')
+			darkToggle.addEventListener('click', function() {
+				document.body.classList.toggle('w3-theme-dark');
+				for (const h of noteHeaders) {
+					h.classList.toggle('note__header--dark')
+				}
+			})
+		}
 	</script>
 </body>
 

--- a/scripts/Entries.js
+++ b/scripts/Entries.js
@@ -6,12 +6,13 @@ export const Entries = () => {
     let allEntriesAsHTML = "";
 
     for (const entry of entries) {
-        allEntriesAsHTML += `
+        // note__header note__header--dark || note__header--light
+        allEntriesAsHTML += /*html*/`
             <div class="w3-card w3-text-theme w3-hover-theme note">
-                <div>
+                <h6 class="note__header--dark || note__header--light note__header" style="text-align: center;">
                     <span><b>Subject: </b></span>
                     <span><u>${entry.subject}</u></span>
-                </div>
+                </h6>
                 <span>${entry.text}</span>
                 <span><i>I felt ${entry.feeling}.</i></span>
                 <span>It took: ${entry.timeSpent} minutes</span>

--- a/styles/main.css
+++ b/styles/main.css
@@ -43,6 +43,26 @@
     flex-flow: column;
 }
 
+.note__header--light {
+    color: #3f51b5;
+}
+
+.note:hover .note__header--light {
+    color: white;
+}
+
+.note:active .note__header--light {
+    color: white;
+}
+
+.note__header--dark {
+    color: white;
+}
+
+/* h6.note__header {
+    color: #FFFFFF;
+} */
+
 .note {
     display: flex;
     flex-flow: column;


### PR DESCRIPTION
Implemented a new version of the darkToggle that also changes the text
color of the note headers. Tapping/hovering will still reveal all text
very readibly, but now it is easier to scan subject lines in dark mode.